### PR TITLE
Merge new script into old one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+# Scripts Repository
+
 ## About This Repository
 
-This repository contains a collection of installer scripts that I use internally for automation with Terraform and Ansible. These scripts help me quickly deploy and switch between different versions of NGINX (as well as Docker, Ansible, Terraform, and Kubernetes) on various systems. The idea is to have a simple, one-command installation that can easily be updated or switched between versions when needed.
+This repository contains a collection of enhanced and complex installer scripts that I use internally for automation (also with Terraform and Ansible). These scripts help me quickly deploy and switch between different versions of NGINX (as well as Docker, Ansible, Terraform, and Kubernetes) on various systems. The idea is to have a simple, one-command installation that can easily be updated or switched between versions when needed.
 
 ---
 
@@ -13,46 +15,44 @@ For example:
 
 ### nginx_installer.sh
 
+This script installs a custom compiled NGINX with OpenSSL 3.5.0 for improved HTTP/3 and QUIC support. The build includes performance optimizations for your specific CPU architecture.
 
-#### Default nginx (mainline)
+#### Install Custom NGINX with HTTP/3 Support
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/main/nginx_installer.sh \
+curl -fsSL https://raw.githubusercontent.com/Stensel8/scripts/main/nginx_installer.sh \
   | sudo bash
 ```
 
-#### Stable
-```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/main/nginx_installer.sh \
-  | sudo bash -s stable
-```
+**Features:**
+- NGINX 1.28.0 (latest stable)
+- OpenSSL 3.5.0 with enhanced QUIC support
+- HTTP/3 module enabled
+- CPU-specific optimizations (`-march=native`)
+- Statically linked OpenSSL for better performance
+- Full feature set including mail, stream, and all standard modules
 
-#### Mainline
-```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/main/nginx_installer.sh \
-  | sudo bash -s mainline
-```
-
+**Note:** The script will detect existing NGINX installations and offer to remove them before installing the custom build.
 ## docker_installer.sh
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/refs/heads/main/docker_installer.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/Stensel8/scripts/refs/heads/main/docker_installer.sh | sudo bash
 ```
 
 ## ansible_installer.sh
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/refs/heads/main/ansible_installer.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/Stensel8/scripts/refs/heads/main/ansible_installer.sh | sudo bash
 ```
 
 ## terraform_installer.sh
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/refs/heads/main/terraform_installer.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/Stensel8/scripts/refs/heads/main/terraform_installer.sh | sudo bash
 ```
 
 ## kubernetes_installer.sh
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Stensel8/basic-scripts/refs/heads/main/kubernetes_installer.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/Stensel8/scripts/refs/heads/main/kubernetes_installer.sh | sudo bash
 ```
 
 ## Enable-WinRM.ps1
 ```ps1
-irm https://raw.githubusercontent.com/Stensel8/basic-scripts/refs/heads/main/Enable-WinRM.ps1 | iex
+irm https://raw.githubusercontent.com/Stensel8/scripts/refs/heads/main/Enable-WinRM.ps1 | iex
 ```

--- a/nginx_installer.sh
+++ b/nginx_installer.sh
@@ -1,580 +1,233 @@
 #!/usr/bin/env bash
 #########################################################################
-# NGINX Installer Script - Based on Official Documentation
+# NGINX 1.28.0 Source Installer for Fedora
+# Compiles latest stable nginx with HTTP/3 support
 #########################################################################
 
-# Enable strict error handling
 set -euo pipefail
 
-#########################################################################
-# CONFIGURATION VARIABLES
-#########################################################################
+NGINX_VERSION="1.28.0"
+BUILD_DIR="/tmp/nginx-build-$$"
+PREFIX="/usr/local/nginx"
 
-# Default to stable release channel
-CHANNEL="stable"
+log_info() { echo -e "\033[0;34m[INFO]\033[0m $1"; }
+log_success() { echo -e "\033[0;32m[SUCCESS]\033[0m $1"; }
+log_error() { echo -e "\033[0;31m[ERROR]\033[0m $1"; }
 
-# Official nginx GPG key fingerprint for verification
-NGINX_GPG_FINGERPRINT="573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62"
-
-# Base URLs
-NGINX_KEY_URL="https://nginx.org/keys/nginx_signing.key"
-NGINX_DOWNLOAD_URL="https://nginx.org/download"
-
-# Current versions (update these when new versions are released)
-STABLE_VERSION="1.28.0"
-MAINLINE_VERSION="1.28.0"
-
-# Log formatting
-LOG_INFO="[INFO]"
-LOG_WARN="[WARN]"
-LOG_ERROR="[ERROR]"
-LOG_SUCCESS="[SUCCESS]"
-
-#########################################################################
-# HELPER FUNCTIONS
-#########################################################################
-
-usage() { 
-    echo "Usage: $0 [-c stable|mainline]" >&2
-    echo "  -c channel: Choose 'stable' or 'mainline' (default: stable)" >&2
+# Check root
+if [ "$EUID" -ne 0 ]; then
+    log_error "Run as root: sudo $0"
     exit 1
-}
+fi
 
-log_info() { echo "${LOG_INFO} $1"; }
-log_warn() { echo "${LOG_WARN} $1"; }
-log_error() { echo "${LOG_ERROR} $1"; }
-log_success() { echo "${LOG_SUCCESS} $1"; }
+log_info "Installing Nginx $NGINX_VERSION from source with HTTP/3"
 
-# Detect Linux distribution with better support
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        case "$ID" in
-            ubuntu) echo "ubuntu" ;;
-            debian) echo "debian" ;;
-            centos|rhel|rocky|alma|ol) echo "rhel" ;;
-            fedora) echo "fedora" ;;
-            opensuse*|sles) echo "suse" ;;
-            alpine) echo "alpine" ;;
-            amzn) echo "amazon" ;;
-            *) echo "unknown" ;;
-        esac
-    else
-        echo "unknown"
-    fi
-}
+# Remove existing nginx
+log_info "Removing existing nginx..."
+systemctl stop nginx 2>/dev/null || true
+dnf remove -y nginx nginx-* 2>/dev/null || true
 
-# Check if distribution/version is officially supported
-check_official_support() {
-    local distro="$1"
-    local version="$2"
-    
-    case "$distro" in
-        rhel)
-            if [[ "$version" =~ ^[89]\..*$ ]]; then
-                return 0
-            fi
-            ;;
-        debian)
-            if [[ "$version" =~ ^1[12]\..*$ ]]; then
-                return 0
-            fi
-            ;;
-        ubuntu)
-            case "$version" in
-                20.04|22.04|24.04|24.10|25.04) return 0 ;;
-            esac
-            ;;
-        suse)
-            if [[ "$version" =~ ^15\..*$ ]]; then
-                return 0
-            fi
-            ;;
-        alpine)
-            if [[ "$version" =~ ^3\.(18|19|20|21)$ ]]; then
-                return 0
-            fi
-            ;;
-        amazon)
-            case "$version" in
-                2|2023) return 0 ;;
-            esac
-            ;;
-        fedora)
-            # Fedora is not officially supported by nginx.org
-            return 1
-            ;;
-    esac
-    return 1
-}
+# Install build dependencies
+log_info "Installing build dependencies..."
+dnf groupinstall -y "Development Tools"
+dnf install -y pcre2-devel zlib-devel openssl-devel wget
 
-# Verify nginx installation
-verify_nginx() {
-    if ! command -v nginx >/dev/null; then
-        log_error "nginx command not found after installation"
-        return 1
-    fi
-    
-    local nginx_ver
-    nginx_ver=$(nginx -v 2>&1)
-    log_info "Installed NGINX version: $nginx_ver"
-    
-    # Check if HTTP/3 is supported
-    if nginx -V 2>&1 | grep -q "http_v3_module\|with-http_v3_module"; then
-        log_success "HTTP/3 support: ✓ Available"
-    else
-        log_warn "HTTP/3 support: ✗ Not available"
-    fi
-    
-    return 0
-}
+# Create build directory
+mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
 
-#########################################################################
-# DISTRIBUTION-SPECIFIC INSTALLATION FUNCTIONS
-#########################################################################
+# Download nginx source
+log_info "Downloading nginx $NGINX_VERSION source..."
+wget "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
+wget "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc"
 
-install_rhel_centos() {
-    log_info "Installing for RHEL/CentOS"
-    
-    # Install prerequisites
-    if command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y yum-utils
-    else
-        sudo yum install -y yum-utils
-    fi
-    
-    # Create repository file
-    sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
-[nginx-stable]
-name=nginx stable repo
-baseurl=http://nginx.org/packages/centos/\$releasever/\$basearch/
-gpgcheck=1
-enabled=1
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
+# Verify signature (optional)
+log_info "Extracting source..."
+tar xf "nginx-${NGINX_VERSION}.tar.gz"
+cd "nginx-${NGINX_VERSION}"
 
-[nginx-mainline]
-name=nginx mainline repo
-baseurl=http://nginx.org/packages/mainline/centos/\$releasever/\$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
-EOF
+# Configure with modules including HTTP/3
+log_info "Configuring build with HTTP/3 and modern modules..."
+./configure \
+    --prefix="$PREFIX" \
+    --sbin-path=/usr/sbin/nginx \
+    --conf-path=/etc/nginx/nginx.conf \
+    --error-log-path=/var/log/nginx/error.log \
+    --http-log-path=/var/log/nginx/access.log \
+    --pid-path=/run/nginx.pid \
+    --lock-path=/run/nginx.lock \
+    --http-client-body-temp-path=/var/cache/nginx/client_temp \
+    --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+    --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+    --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+    --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+    --user=nginx \
+    --group=nginx \
+    --with-compat \
+    --with-file-aio \
+    --with-threads \
+    --with-http_addition_module \
+    --with-http_auth_request_module \
+    --with-http_dav_module \
+    --with-http_flv_module \
+    --with-http_gunzip_module \
+    --with-http_gzip_static_module \
+    --with-http_mp4_module \
+    --with-http_random_index_module \
+    --with-http_realip_module \
+    --with-http_secure_link_module \
+    --with-http_slice_module \
+    --with-http_ssl_module \
+    --with-http_stub_status_module \
+    --with-http_sub_module \
+    --with-http_v2_module \
+    --with-http_v3_module \
+    --with-mail \
+    --with-mail_ssl_module \
+    --with-stream \
+    --with-stream_realip_module \
+    --with-stream_ssl_module \
+    --with-stream_ssl_preread_module
 
-    # Enable mainline if requested
-    if [ "$CHANNEL" = "mainline" ]; then
-        sudo yum-config-manager --enable nginx-mainline --disable nginx-stable
-    fi
-    
-    # Install nginx
-    if command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y nginx
-    else
-        sudo yum install -y nginx
-    fi
-}
+# Build
+log_info "Building nginx (this may take several minutes)..."
+make -j"$(nproc)"
 
-install_fedora() {
-    log_warn "Fedora is not officially supported by nginx.org"
-    log_info "Attempting to use RHEL packages as fallback"
-    
-    # Try to use RHEL 9 packages for newer Fedora
-    local fedora_ver
-    fedora_ver=$(rpm -E %fedora)
-    local rhel_ver="9"
-    
-    if [ "$fedora_ver" -lt 38 ]; then
-        rhel_ver="8"
-    fi
-    
-    log_info "Using RHEL $rhel_ver packages for Fedora $fedora_ver"
-    
-    # Install prerequisites
-    sudo dnf install -y yum-utils
-    
-    # Create repository file with RHEL compatibility
-    sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
-[nginx-stable]
-name=nginx stable repo
-baseurl=http://nginx.org/packages/centos/${rhel_ver}/\$basearch/
-gpgcheck=1
-enabled=1
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
+# Install
+log_info "Installing nginx..."
+make install
 
-[nginx-mainline]
-name=nginx mainline repo
-baseurl=http://nginx.org/packages/mainline/centos/${rhel_ver}/\$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
-EOF
+# Create nginx user
+log_info "Creating nginx user..."
+useradd --system --home /var/cache/nginx --shell /sbin/nologin --comment "nginx user" --user-group nginx 2>/dev/null || true
 
-    # Enable mainline if requested
-    if [ "$CHANNEL" = "mainline" ]; then
-        sudo dnf config-manager --set-enabled nginx-mainline --set-disabled nginx-stable
-    fi
-    
-    # Install nginx
-    if ! sudo dnf install -y nginx; then
-        log_error "Failed to install from nginx.org repository"
-        log_info "Falling back to Fedora's own nginx package"
-        sudo dnf remove -y nginx 2>/dev/null || true
-        sudo rm -f /etc/yum.repos.d/nginx.repo
-        sudo dnf install -y nginx
-        log_warn "Using Fedora's nginx package (may be older version)"
-    fi
-}
+# Create required directories
+log_info "Creating required directories..."
+mkdir -p /var/cache/nginx/{client_temp,proxy_temp,fastcgi_temp,uwsgi_temp,scgi_temp}
+mkdir -p /var/log/nginx
+mkdir -p /etc/nginx/{conf.d,snippets}
 
-install_debian_ubuntu() {
-    local distro="$1"
-    log_info "Installing for $distro"
-    
-    # Install prerequisites
-    if [ "$distro" = "ubuntu" ]; then
-        sudo apt install -y curl gnupg2 ca-certificates lsb-release ubuntu-keyring
-    else
-        sudo apt install -y curl gnupg2 ca-certificates lsb-release debian-archive-keyring
-    fi
-    
-    # Import nginx signing key
-    curl -fsSL ${NGINX_KEY_URL} | gpg --dearmor \
-        | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-    
-    # Verify key fingerprint
-    if ! gpg --dry-run --quiet --no-keyring --import --import-options import-show \
-        /usr/share/keyrings/nginx-archive-keyring.gpg 2>/dev/null | grep -q "$NGINX_GPG_FINGERPRINT"; then
-        log_error "GPG key verification failed!"
-        return 1
-    fi
-    
-    # Set up repository
-    local repo_url
-    if [ "$CHANNEL" = "mainline" ]; then
-        repo_url="http://nginx.org/packages/mainline/$distro"
-    else
-        repo_url="http://nginx.org/packages/$distro"
-    fi
-    
-    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] $repo_url $(lsb_release -cs) nginx" \
-        | sudo tee /etc/apt/sources.list.d/nginx.list
-    
-    # Set up repository pinning
-    echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" \
-        | sudo tee /etc/apt/preferences.d/99nginx
-    
-    # Install nginx
-    sudo apt update
-    sudo apt install -y nginx
-}
+# Set permissions
+chown -R nginx:nginx /var/cache/nginx /var/log/nginx
+chmod 755 /var/cache/nginx /var/log/nginx
 
-install_alpine() {
-    log_info "Installing for Alpine Linux"
-    
-    # Install prerequisites
-    sudo apk add openssl curl ca-certificates
-    
-    # Set up repository
-    local repo_url
-    local alpine_ver
-    alpine_ver=$(grep -o '^[0-9]\+\.[0-9]\+' /etc/alpine-release)
-    
-    if [ "$CHANNEL" = "mainline" ]; then
-        repo_url="http://nginx.org/packages/mainline/alpine/v${alpine_ver}/main"
-    else
-        repo_url="http://nginx.org/packages/alpine/v${alpine_ver}/main"
-    fi
-    
-    echo "@nginx $repo_url" | sudo tee -a /etc/apk/repositories
-    
-    # Import signing key
-    curl -fsSL https://nginx.org/keys/nginx_signing.rsa.pub -o /tmp/nginx_signing.rsa.pub
-    sudo mv /tmp/nginx_signing.rsa.pub /etc/apk/keys/
-    
-    # Install nginx
-    sudo apk add nginx@nginx
-}
-
-install_amazon() {
-    log_info "Installing for Amazon Linux"
-    
-    # Install prerequisites
-    sudo yum install -y yum-utils
-    
-    # Detect Amazon Linux version
-    local amzn_ver
-    if grep -q "Amazon Linux 2023" /etc/os-release; then
-        amzn_ver="2023"
-    else
-        amzn_ver="2"
-    fi
-    
-    # Create repository file
-    if [ "$amzn_ver" = "2023" ]; then
-        sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
-[nginx-stable]
-name=nginx stable repo
-baseurl=http://nginx.org/packages/amzn/2023/\$basearch/
-gpgcheck=1
-enabled=1
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
-priority=9
-
-[nginx-mainline]
-name=nginx mainline repo
-baseurl=http://nginx.org/packages/mainline/amzn/2023/\$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
-priority=9
-EOF
-    else
-        sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
-[nginx-stable]
-name=nginx stable repo
-baseurl=http://nginx.org/packages/amzn2/\$releasever/\$basearch/
-gpgcheck=1
-enabled=1
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
-priority=9
-
-[nginx-mainline]
-name=nginx mainline repo
-baseurl=http://nginx.org/packages/mainline/amzn2/\$releasever/\$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=${NGINX_KEY_URL}
-module_hotfixes=true
-priority=9
-EOF
-    fi
-    
-    # Enable mainline if requested
-    if [ "$CHANNEL" = "mainline" ]; then
-        sudo yum-config-manager --enable nginx-mainline --disable nginx-stable
-    fi
-    
-    # Install nginx
-    sudo yum install -y nginx
-}
-
-#########################################################################
-# SOURCE INSTALLATION (FALLBACK)
-#########################################################################
-
-install_from_source() {
-    log_info "Installing NGINX from source as fallback"
-    
-    # Set version based on channel
-    local version
-    if [ "$CHANNEL" = "stable" ]; then
-        version="$STABLE_VERSION"
-    else
-        version="$MAINLINE_VERSION"
-    fi
-    
-    # Create build directory
-    local build_dir="/tmp/nginx-build-$$"
-    mkdir -p "$build_dir" && cd "$build_dir"
-    
-    # Install build dependencies based on distribution
-    case "$DISTRO" in
-        debian|ubuntu)
-            sudo apt update
-            sudo apt install -y build-essential libpcre3-dev zlib1g-dev libssl-dev
-            ;;
-        rhel|fedora)
-            if command -v dnf >/dev/null; then
-                sudo dnf groupinstall -y "Development Tools"
-                sudo dnf install -y pcre-devel zlib-devel openssl-devel
-            else
-                sudo yum groupinstall -y "Development Tools"
-                sudo yum install -y pcre-devel zlib-devel openssl-devel
-            fi
-            ;;
-        alpine)
-            sudo apk add build-base pcre-dev zlib-dev openssl-dev
-            ;;
-        *)
-            log_error "Cannot install build dependencies for $DISTRO"
-            return 1
-            ;;
-    esac
-    
-    # Download and verify source
-    log_info "Downloading NGINX $version source"
-    curl -fsSL "${NGINX_DOWNLOAD_URL}/nginx-${version}.tar.gz" -o nginx.tar.gz
-    curl -fsSL "${NGINX_DOWNLOAD_URL}/nginx-${version}.tar.gz.asc" -o nginx.tar.gz.asc
-    
-    # Import key and verify (if possible)
-    if command -v gpg >/dev/null; then
-        curl -fsSL "$NGINX_KEY_URL" | gpg --import 2>/dev/null || true
-        gpg --verify nginx.tar.gz.asc nginx.tar.gz 2>/dev/null || log_warn "GPG verification failed or not possible"
-    fi
-    
-    # Extract and build
-    tar xf nginx.tar.gz
-    cd "nginx-${version}"
-    
-    # Configure with modules including HTTP/3
-    log_info "Configuring build with HTTP/3 support"
-    ./configure \
-        --prefix=/usr/local/nginx \
-        --sbin-path=/usr/local/sbin/nginx \
-        --conf-path=/etc/nginx/nginx.conf \
-        --error-log-path=/var/log/nginx/error.log \
-        --http-log-path=/var/log/nginx/access.log \
-        --pid-path=/var/run/nginx.pid \
-        --lock-path=/var/run/nginx.lock \
-        --with-http_ssl_module \
-        --with-http_v2_module \
-        --with-http_v3_module \
-        --with-http_realip_module \
-        --with-http_stub_status_module \
-        --with-http_gzip_static_module \
-        --with-stream \
-        --with-stream_ssl_module
-    
-    # Build and install
-    log_info "Building NGINX (this may take several minutes)"
-    make -j"$(nproc 2>/dev/null || echo 2)"
-    sudo make install
-    
-    # Create systemd service
-    sudo tee /etc/systemd/system/nginx.service > /dev/null <<EOF
+# Create systemd service
+log_info "Creating systemd service..."
+cat > /etc/systemd/system/nginx.service << 'EOF'
 [Unit]
 Description=The NGINX HTTP and reverse proxy server
+Documentation=http://nginx.org/en/docs/
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/nginx.pid
-ExecStartPre=/usr/local/sbin/nginx -t
-ExecStart=/usr/local/sbin/nginx
-ExecReload=/usr/local/sbin/nginx -s reload
-ExecStop=/bin/kill -s QUIT \$MAINPID
+PIDFile=/run/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t
+ExecStart=/usr/sbin/nginx
+ExecReload=/usr/sbin/nginx -s reload
+ExecStop=/bin/kill -s QUIT $MAINPID
+KillSignal=SIGQUIT
+TimeoutStopSec=5
+KillMode=mixed
 PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target
 EOF
-    
-    # Create symlink
-    sudo ln -sf /usr/local/sbin/nginx /usr/bin/nginx
-    
-    # Reload systemd
-    sudo systemctl daemon-reload
-    
-    # Cleanup
-    cd / && rm -rf "$build_dir"
-    
-    log_success "NGINX $version compiled and installed from source"
+
+# Create basic nginx.conf if it doesn't exist
+if [ ! -f /etc/nginx/nginx.conf ]; then
+    log_info "Creating basic nginx.conf..."
+    cat > /etc/nginx/nginx.conf << 'EOF'
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
 }
 
-#########################################################################
-# MAIN INSTALLATION LOGIC
-#########################################################################
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
 
-main() {
-    # Parse command line options
-    while getopts "c:" opt; do
-        case $opt in
-            c) 
-                if [[ "$OPTARG" =~ ^(stable|mainline)$ ]]; then
-                    CHANNEL="$OPTARG"
-                else
-                    log_error "Channel must be 'stable' or 'mainline'"
-                    usage
-                fi
-                ;;
-            *) usage ;;
-        esac
-    done
-    
-    # Also support direct parameter (for piping)
-    if [ $# -eq 1 ] && [[ "$1" =~ ^(stable|mainline)$ ]]; then
-        CHANNEL="$1"
-    fi
-    
-    # Check for root privileges
-    if [ "$EUID" -ne 0 ]; then
-        log_error "This script must be run as root (use sudo)"
-        exit 1
-    fi
-    
-    # Detect distribution
-    DISTRO=$(detect_distro)
-    log_info "Detected distribution: $DISTRO"
-    log_info "Selected channel: $CHANNEL"
-    
-    # Get distribution version
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        VERSION_ID="${VERSION_ID:-unknown}"
-    else
-        VERSION_ID="unknown"
-    fi
-    
-    # Check official support
-    if check_official_support "$DISTRO" "$VERSION_ID"; then
-        log_info "Distribution officially supported by nginx.org"
-    else
-        log_warn "Distribution not officially supported by nginx.org"
-        log_info "Will attempt installation anyway or fall back to source"
-    fi
-    
-    # Stop existing nginx if running
-    if systemctl is-active --quiet nginx 2>/dev/null; then
-        log_info "Stopping existing nginx service"
-        sudo systemctl stop nginx
-    fi
-    
-    # Install based on distribution
-    case "$DISTRO" in
-        rhel)
-            install_rhel_centos
-            ;;
-        fedora)
-            install_fedora
-            ;;
-        debian)
-            install_debian_ubuntu debian
-            ;;
-        ubuntu)
-            install_debian_ubuntu ubuntu
-            ;;
-        alpine)
-            install_alpine
-            ;;
-        amazon)
-            install_amazon
-            ;;
-        *)
-            log_warn "Unsupported distribution, falling back to source installation"
-            install_from_source
-            ;;
-    esac
-    
-    # Verify installation
-    if verify_nginx; then
-        log_success "NGINX installation completed successfully"
-        
-        # Enable and start service
-        sudo systemctl enable nginx
-        sudo systemctl start nginx
-        
-        log_info "NGINX service enabled and started"
-        log_info "You can check status with: sudo systemctl status nginx"
-    else
-        log_error "NGINX installation verification failed"
-        exit 1
-    fi
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80 default_server;
+        listen       [::]:80 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
 }
+EOF
+fi
 
-# Run main function
-main "$@"
+# Create default web root
+mkdir -p /usr/share/nginx/html
+cat > /usr/share/nginx/html/index.html << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Welcome to nginx!</title>
+</head>
+<body>
+    <h1>Welcome to nginx!</h1>
+    <p>nginx 1.28.0 with HTTP/3 support</p>
+    <p>Compiled from source on Fedora</p>
+</body>
+</html>
+EOF
+
+# Reload systemd and enable service
+systemctl daemon-reload
+systemctl enable nginx
+
+# Test configuration
+log_info "Testing nginx configuration..."
+/usr/sbin/nginx -t
+
+# Start nginx
+log_info "Starting nginx..."
+systemctl start nginx
+
+# Cleanup build directory
+cd / && rm -rf "$BUILD_DIR"
+
+# Verify installation
+log_success "Nginx $NGINX_VERSION installation completed!"
+nginx_version=$(/usr/sbin/nginx -v 2>&1)
+log_info "Installed version: $nginx_version"
+
+# Check HTTP/3 support
+if /usr/sbin/nginx -V 2>&1 | grep -q "http_v3_module"; then
+    log_success "✓ HTTP/3 support available"
+else
+    log_error "✗ HTTP/3 support not available"
+fi
+
+log_info "Nginx is running and enabled for startup"
+log_info "Configuration files are in /etc/nginx/"
+log_info "You can check status with: sudo systemctl status nginx"

--- a/nginx_installer.sh
+++ b/nginx_installer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #########################################################################
-# NGINX Installer Script - Optimized with GitHub Copilot
+# NGINX Installer Script - Based on Official Documentation
 #########################################################################
 
 # Enable strict error handling
@@ -10,16 +10,19 @@ set -euo pipefail
 # CONFIGURATION VARIABLES
 #########################################################################
 
-# Default to mainline release channel
-CHANNEL="mainline"
+# Default to stable release channel
+CHANNEL="stable"
 
-# Version mapping - update these when new versions are released
-STABLE_VERSION="1.28.0"
-MAINLINE_VERSION="1.27.5"
+# Official nginx GPG key fingerprint for verification
+NGINX_GPG_FINGERPRINT="573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62"
 
-# Base URL for downloads
-NGINX_DOWNLOAD_URL="https://nginx.org/download"
+# Base URLs
 NGINX_KEY_URL="https://nginx.org/keys/nginx_signing.key"
+NGINX_DOWNLOAD_URL="https://nginx.org/download"
+
+# Current versions (update these when new versions are released)
+STABLE_VERSION="1.28.0"
+MAINLINE_VERSION="1.28.0"
 
 # Log formatting
 LOG_INFO="[INFO]"
@@ -31,280 +34,426 @@ LOG_SUCCESS="[SUCCESS]"
 # HELPER FUNCTIONS
 #########################################################################
 
-# Display usage information
 usage() { 
-    echo "Usage: $0 [-s stable|mainline]" >&2
+    echo "Usage: $0 [-c stable|mainline]" >&2
+    echo "  -c channel: Choose 'stable' or 'mainline' (default: stable)" >&2
     exit 1
 }
 
-# Print formatted log messages
 log_info() { echo "${LOG_INFO} $1"; }
 log_warn() { echo "${LOG_WARN} $1"; }
 log_error() { echo "${LOG_ERROR} $1"; }
 log_success() { echo "${LOG_SUCCESS} $1"; }
 
-# Detect Linux distribution
+# Detect Linux distribution with better support
 detect_distro() {
-  # Source the OS release information
-  . /etc/os-release
-  
-  # Return simplified distribution category
-  case "$ID" in
-    ubuntu|debian) echo "debian" ;;
-    centos|rhel|rocky|alma) echo "rhel" ;;
-    fedora) echo "fedora" ;;
-    opensuse*|sles) echo "suse" ;;
-    arch) echo "arch" ;;
-    *) echo "unknown" ;;
-  esac
-}
-
-# Verify NGINX installation and version
-verify_nginx_version() {
-  if ! command -v nginx >/dev/null; then
-    log_error "nginx command not found after installation"
-    return 1
-  fi
-  
-  # Get NGINX version
-  NGINX_VER=$(nginx -v 2>&1)
-  log_info "Installed NGINX version: $NGINX_VER"
-    # If using a local distribution package, don't enforce exact version match
-  if echo "$NGINX_VER" | grep -q "nginx/[0-9]"; then
-    # Check if we were able to get a package from the official NGINX repo
-    if grep -q "packages/${CHANNEL}" /etc/yum.repos.d/nginx.repo 2>/dev/null || 
-       grep -q "packages/${CHANNEL}" /etc/apt/sources.list.d/nginx.list 2>/dev/null; then
-      
-      # Only then check version match
-      if [ "$CHANNEL" = "stable" ] && ! echo "$NGINX_VER" | grep -q "1.28"; then
-        log_error "Installed version does not match stable channel (expected 1.28.x)"
-        return 1
-      elif [ "$CHANNEL" = "mainline" ] && ! echo "$NGINX_VER" | grep -q "1.27"; then
-        log_error "Installed version does not match mainline channel (expected 1.27.x)"
-        return 1
-      fi
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        case "$ID" in
+            ubuntu) echo "ubuntu" ;;
+            debian) echo "debian" ;;
+            centos|rhel|rocky|alma|ol) echo "rhel" ;;
+            fedora) echo "fedora" ;;
+            opensuse*|sles) echo "suse" ;;
+            alpine) echo "alpine" ;;
+            amzn) echo "amazon" ;;
+            *) echo "unknown" ;;
+        esac
     else
-      # Using distribution package, log a warning but accept it
-      log_warn "Using distribution-provided NGINX package (${NGINX_VER}), not official NGINX repo package"
+        echo "unknown"
     fi
-  else
-    log_error "Unexpected NGINX version format: ${NGINX_VER}"
+}
+
+# Check if distribution/version is officially supported
+check_official_support() {
+    local distro="$1"
+    local version="$2"
+    
+    case "$distro" in
+        rhel)
+            if [[ "$version" =~ ^[89]\..*$ ]]; then
+                return 0
+            fi
+            ;;
+        debian)
+            if [[ "$version" =~ ^1[12]\..*$ ]]; then
+                return 0
+            fi
+            ;;
+        ubuntu)
+            case "$version" in
+                20.04|22.04|24.04|24.10|25.04) return 0 ;;
+            esac
+            ;;
+        suse)
+            if [[ "$version" =~ ^15\..*$ ]]; then
+                return 0
+            fi
+            ;;
+        alpine)
+            if [[ "$version" =~ ^3\.(18|19|20|21)$ ]]; then
+                return 0
+            fi
+            ;;
+        amazon)
+            case "$version" in
+                2|2023) return 0 ;;
+            esac
+            ;;
+        fedora)
+            # Fedora is not officially supported by nginx.org
+            return 1
+            ;;
+    esac
     return 1
-  fi
-  
-  return 0
+}
+
+# Verify nginx installation
+verify_nginx() {
+    if ! command -v nginx >/dev/null; then
+        log_error "nginx command not found after installation"
+        return 1
+    fi
+    
+    local nginx_ver
+    nginx_ver=$(nginx -v 2>&1)
+    log_info "Installed NGINX version: $nginx_ver"
+    
+    # Check if HTTP/3 is supported
+    if nginx -V 2>&1 | grep -q "http_v3_module\|with-http_v3_module"; then
+        log_success "HTTP/3 support: ✓ Available"
+    else
+        log_warn "HTTP/3 support: ✗ Not available"
+    fi
+    
+    return 0
 }
 
 #########################################################################
-# PACKAGE INSTALLATION FUNCTION
+# DISTRIBUTION-SPECIFIC INSTALLATION FUNCTIONS
 #########################################################################
 
-install_nginx_package() {
-  case "$DISTRO" in
-    debian)      # Detect Ubuntu or Debian
-      if grep -qi "ubuntu" /etc/os-release; then
-        OS_TYPE="ubuntu"
-        RELEASE="$(lsb_release -cs)"
-        
-        # Use the actual release name for Ubuntu - Noble and Plucky are supported
-        log_info "Detected Ubuntu ${RELEASE}"
-      else
-        OS_TYPE="debian"
-        RELEASE="$(lsb_release -cs)"
-      fi
-      
-      # Import NGINX signing key
-      log_info "Importing NGINX signing key"
-      curl -fsSL ${NGINX_KEY_URL} | gpg --dearmor \
-        | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-        # Configure repository
-      log_info "Configuring ${OS_TYPE} repository for ${CHANNEL} channel"
-        # Different repository URL formats for Ubuntu vs Debian
-      if [ "$OS_TYPE" = "ubuntu" ]; then
-        cat <<EOF >/etc/apt/sources.list.d/nginx.list
-# nginx ${CHANNEL} for Ubuntu
-deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-  https://nginx.org/packages/ubuntu/ \
-  ${RELEASE} nginx
-EOF
-      else
-        cat <<EOF >/etc/apt/sources.list.d/nginx.list
-# nginx ${CHANNEL} for Debian
-deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-  http://nginx.org/packages/${CHANNEL}/${OS_TYPE} \
-  ${RELEASE} nginx
-EOF
-      fi
-
-      # Update package lists and install
-      if ! apt-get update 2>/dev/null; then
-        log_error "Repository update failed - package might not be available"
-        return 1
-      fi
-      
-      log_info "Installing NGINX package"
-      if ! apt-get install -y nginx; then
-        log_error "Failed to install nginx from package repository"
-        return 1
-      fi
-      ;;
-
-    rhel|fedora)
-      # For newer Fedora versions that might not be supported 
-      if [ "$DISTRO" = "fedora" ]; then
-        RELVER=$(rpm -E %fedora)
-        if [ "$RELVER" -ge 38 ]; then
-          log_warn "Fedora $RELVER might not have official nginx packages, trying anyway"
-        fi
-      fi
-        # Configure repository
-      log_info "Configuring ${DISTRO} repository for ${CHANNEL} channel"
-      cat <<EOF >/etc/yum.repos.d/nginx.repo
-[nginx-${CHANNEL}]
-name=nginx ${CHANNEL} repo
-baseurl=http://nginx.org/packages/${CHANNEL}/$([ "$DISTRO" = "fedora" ] && echo "fedora" || echo "rhel")/\$releasever/\$basearch/
+install_rhel_centos() {
+    log_info "Installing for RHEL/CentOS"
+    
+    # Install prerequisites
+    if command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y yum-utils
+    else
+        sudo yum install -y yum-utils
+    fi
+    
+    # Create repository file
+    sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
+[nginx-stable]
+name=nginx stable repo
+baseurl=http://nginx.org/packages/centos/\$releasever/\$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/centos/\$releasever/\$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
 EOF
 
-      # Install package using appropriate package manager
-      log_info "Installing NGINX package"
-      if command -v dnf &>/dev/null; then
-        if ! dnf -y --refresh install nginx; then
-          log_error "Failed to install nginx from package repository"
-          return 1
-        fi
-      else
-        if ! yum -y install nginx; then
-          log_error "Failed to install nginx from package repository"
-          return 1
-        fi
-      fi
-      ;;
+    # Enable mainline if requested
+    if [ "$CHANNEL" = "mainline" ]; then
+        sudo yum-config-manager --enable nginx-mainline --disable nginx-stable
+    fi
+    
+    # Install nginx
+    if command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y nginx
+    else
+        sudo yum install -y nginx
+    fi
+}
 
-    suse)
-      # Configure repository
-      log_info "Configuring openSUSE repository for ${CHANNEL} channel"
-      zypper addrepo --name nginx-${CHANNEL} \
-        http://nginx.org/packages/${CHANNEL}/opensuse/$(. /etc/os-release && echo $VERSION_ID)/ nginx
-      
-      # Refresh package lists and install
-      zypper --gpg-auto-import-keys refresh
-      log_info "Installing NGINX package"
-      if ! zypper install -y nginx; then
-        log_error "Failed to install nginx from package repository"
+install_fedora() {
+    log_warn "Fedora is not officially supported by nginx.org"
+    log_info "Attempting to use RHEL packages as fallback"
+    
+    # Try to use RHEL 9 packages for newer Fedora
+    local fedora_ver
+    fedora_ver=$(rpm -E %fedora)
+    local rhel_ver="9"
+    
+    if [ "$fedora_ver" -lt 38 ]; then
+        rhel_ver="8"
+    fi
+    
+    log_info "Using RHEL $rhel_ver packages for Fedora $fedora_ver"
+    
+    # Install prerequisites
+    sudo dnf install -y yum-utils
+    
+    # Create repository file with RHEL compatibility
+    sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
+[nginx-stable]
+name=nginx stable repo
+baseurl=http://nginx.org/packages/centos/${rhel_ver}/\$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/centos/${rhel_ver}/\$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+EOF
+
+    # Enable mainline if requested
+    if [ "$CHANNEL" = "mainline" ]; then
+        sudo dnf config-manager --set-enabled nginx-mainline --set-disabled nginx-stable
+    fi
+    
+    # Install nginx
+    if ! sudo dnf install -y nginx; then
+        log_error "Failed to install from nginx.org repository"
+        log_info "Falling back to Fedora's own nginx package"
+        sudo dnf remove -y nginx 2>/dev/null || true
+        sudo rm -f /etc/yum.repos.d/nginx.repo
+        sudo dnf install -y nginx
+        log_warn "Using Fedora's nginx package (may be older version)"
+    fi
+}
+
+install_debian_ubuntu() {
+    local distro="$1"
+    log_info "Installing for $distro"
+    
+    # Install prerequisites
+    if [ "$distro" = "ubuntu" ]; then
+        sudo apt install -y curl gnupg2 ca-certificates lsb-release ubuntu-keyring
+    else
+        sudo apt install -y curl gnupg2 ca-certificates lsb-release debian-archive-keyring
+    fi
+    
+    # Import nginx signing key
+    curl -fsSL ${NGINX_KEY_URL} | gpg --dearmor \
+        | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+    
+    # Verify key fingerprint
+    if ! gpg --dry-run --quiet --no-keyring --import --import-options import-show \
+        /usr/share/keyrings/nginx-archive-keyring.gpg 2>/dev/null | grep -q "$NGINX_GPG_FINGERPRINT"; then
+        log_error "GPG key verification failed!"
         return 1
-      fi
-      ;;
+    fi
+    
+    # Set up repository
+    local repo_url
+    if [ "$CHANNEL" = "mainline" ]; then
+        repo_url="http://nginx.org/packages/mainline/$distro"
+    else
+        repo_url="http://nginx.org/packages/$distro"
+    fi
+    
+    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] $repo_url $(lsb_release -cs) nginx" \
+        | sudo tee /etc/apt/sources.list.d/nginx.list
+    
+    # Set up repository pinning
+    echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" \
+        | sudo tee /etc/apt/preferences.d/99nginx
+    
+    # Install nginx
+    sudo apt update
+    sudo apt install -y nginx
+}
 
-    arch)
-      # Install from Arch repositories
-      log_info "Installing NGINX from Arch repositories"
-      if ! pacman -Sy --noconfirm nginx; then
-        log_error "Failed to install nginx from package repository"
-        return 1
-      fi
-      ;;
+install_alpine() {
+    log_info "Installing for Alpine Linux"
+    
+    # Install prerequisites
+    sudo apk add openssl curl ca-certificates
+    
+    # Set up repository
+    local repo_url
+    local alpine_ver
+    alpine_ver=$(grep -o '^[0-9]\+\.[0-9]\+' /etc/alpine-release)
+    
+    if [ "$CHANNEL" = "mainline" ]; then
+        repo_url="http://nginx.org/packages/mainline/alpine/v${alpine_ver}/main"
+    else
+        repo_url="http://nginx.org/packages/alpine/v${alpine_ver}/main"
+    fi
+    
+    echo "@nginx $repo_url" | sudo tee -a /etc/apk/repositories
+    
+    # Import signing key
+    curl -fsSL https://nginx.org/keys/nginx_signing.rsa.pub -o /tmp/nginx_signing.rsa.pub
+    sudo mv /tmp/nginx_signing.rsa.pub /etc/apk/keys/
+    
+    # Install nginx
+    sudo apk add nginx@nginx
+}
 
-    *) 
-      log_error "Unsupported distribution"
-      return 1
-      ;;
-  esac
-    # Verify installation and version
-  verify_nginx_version
-  return $?
+install_amazon() {
+    log_info "Installing for Amazon Linux"
+    
+    # Install prerequisites
+    sudo yum install -y yum-utils
+    
+    # Detect Amazon Linux version
+    local amzn_ver
+    if grep -q "Amazon Linux 2023" /etc/os-release; then
+        amzn_ver="2023"
+    else
+        amzn_ver="2"
+    fi
+    
+    # Create repository file
+    if [ "$amzn_ver" = "2023" ]; then
+        sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
+[nginx-stable]
+name=nginx stable repo
+baseurl=http://nginx.org/packages/amzn/2023/\$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+priority=9
+
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/amzn/2023/\$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+priority=9
+EOF
+    else
+        sudo tee /etc/yum.repos.d/nginx.repo > /dev/null <<EOF
+[nginx-stable]
+name=nginx stable repo
+baseurl=http://nginx.org/packages/amzn2/\$releasever/\$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+priority=9
+
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=http://nginx.org/packages/mainline/amzn2/\$releasever/\$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=${NGINX_KEY_URL}
+module_hotfixes=true
+priority=9
+EOF
+    fi
+    
+    # Enable mainline if requested
+    if [ "$CHANNEL" = "mainline" ]; then
+        sudo yum-config-manager --enable nginx-mainline --disable nginx-stable
+    fi
+    
+    # Install nginx
+    sudo yum install -y nginx
 }
 
 #########################################################################
-# SOURCE INSTALLATION FUNCTION
+# SOURCE INSTALLATION (FALLBACK)
 #########################################################################
 
-install_nginx_from_source() {
-  log_info "Building NGINX from source"
-  log_info "This will ensure you get the correct version for the selected channel"
-  
-  # Set version based on channel
-  if [ "$CHANNEL" = "stable" ]; then
-    VER="${STABLE_VERSION}"
-  else
-    VER="${MAINLINE_VERSION}"
-  fi
+install_from_source() {
+    log_info "Installing NGINX from source as fallback"
+    
+    # Set version based on channel
+    local version
+    if [ "$CHANNEL" = "stable" ]; then
+        version="$STABLE_VERSION"
+    else
+        version="$MAINLINE_VERSION"
+    fi
+    
     # Create build directory
-  BUILD_DIR="/tmp/nginx-build"
-  log_info "Creating build directory: ${BUILD_DIR}"
-  mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
-  
-  # Download source and signature
-  log_info "Downloading NGINX ${VER} source code"
-  curl -fsSL ${NGINX_DOWNLOAD_URL}/nginx-${VER}.tar.gz -o nginx.tar.gz
-  curl -fsSL ${NGINX_DOWNLOAD_URL}/nginx-${VER}.tar.gz.asc -o nginx.tar.gz.asc
-  
-  # Import key and verify signature
-  log_info "Verifying package signature"
-  gpg --batch --import <(curl -fsSL ${NGINX_KEY_URL})
-  gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz || log_warn "Signature verification failed, continuing anyway"
-    # Check for required build dependencies and install them
-  log_info "Checking for and installing build dependencies"
-  case "$DISTRO" in
-    debian)
-      log_info "Installing build dependencies for Debian/Ubuntu"
-      apt-get update -qq
-      apt-get install -y build-essential libpcre3-dev zlib1g-dev libssl-dev
-      ;;
-    rhel|fedora)
-      log_info "Installing build dependencies for RHEL/Fedora"
-      if command -v dnf &>/dev/null; then
-        dnf -y install gcc make pcre-devel zlib-devel openssl-devel
-      else
-        yum -y install gcc make pcre-devel zlib-devel openssl-devel
-      fi
-      ;;
-    suse)
-      log_info "Installing build dependencies for openSUSE"
-      zypper install -y gcc make pcre-devel zlib-devel libopenssl-devel
-      ;;
-    arch)
-      log_info "Installing build dependencies for Arch Linux"
-      pacman -S --noconfirm gcc make pcre zlib openssl
-      ;;
-    *)
-      log_error "Unsupported distribution for source build"
-      return 1
-      ;;
-  esac
-  
-  # Extract and build
-  log_info "Extracting source code"
-  tar xf nginx.tar.gz
-  cd nginx-${VER}
-  
-  # Configure with standard modules
-  log_info "Configuring build with HTTP SSL and Stream modules"
-  ./configure --with-http_ssl_module --with-stream --prefix=/usr/local
-  
-  # Build and install
-  log_info "Compiling NGINX (this may take a while)"
-  make -j"$(nproc || echo 1)"
-  log_info "Installing NGINX to /usr/local"
-  make install
-  
-  # Create symlink to make it available in PATH
-  log_info "Creating symlink in /usr/bin for easier access"
-  ln -sf /usr/local/sbin/nginx /usr/bin/nginx 2>/dev/null || log_warn "Failed to create symlink"
-  
-  # Install systemd service file if it doesn't exist
-  if [ ! -f /etc/systemd/system/nginx.service ]; then
-    log_info "Creating systemd service file"
-    cat > /etc/systemd/system/nginx.service <<EOF
+    local build_dir="/tmp/nginx-build-$$"
+    mkdir -p "$build_dir" && cd "$build_dir"
+    
+    # Install build dependencies based on distribution
+    case "$DISTRO" in
+        debian|ubuntu)
+            sudo apt update
+            sudo apt install -y build-essential libpcre3-dev zlib1g-dev libssl-dev
+            ;;
+        rhel|fedora)
+            if command -v dnf >/dev/null; then
+                sudo dnf groupinstall -y "Development Tools"
+                sudo dnf install -y pcre-devel zlib-devel openssl-devel
+            else
+                sudo yum groupinstall -y "Development Tools"
+                sudo yum install -y pcre-devel zlib-devel openssl-devel
+            fi
+            ;;
+        alpine)
+            sudo apk add build-base pcre-dev zlib-dev openssl-dev
+            ;;
+        *)
+            log_error "Cannot install build dependencies for $DISTRO"
+            return 1
+            ;;
+    esac
+    
+    # Download and verify source
+    log_info "Downloading NGINX $version source"
+    curl -fsSL "${NGINX_DOWNLOAD_URL}/nginx-${version}.tar.gz" -o nginx.tar.gz
+    curl -fsSL "${NGINX_DOWNLOAD_URL}/nginx-${version}.tar.gz.asc" -o nginx.tar.gz.asc
+    
+    # Import key and verify (if possible)
+    if command -v gpg >/dev/null; then
+        curl -fsSL "$NGINX_KEY_URL" | gpg --import 2>/dev/null || true
+        gpg --verify nginx.tar.gz.asc nginx.tar.gz 2>/dev/null || log_warn "GPG verification failed or not possible"
+    fi
+    
+    # Extract and build
+    tar xf nginx.tar.gz
+    cd "nginx-${version}"
+    
+    # Configure with modules including HTTP/3
+    log_info "Configuring build with HTTP/3 support"
+    ./configure \
+        --prefix=/usr/local/nginx \
+        --sbin-path=/usr/local/sbin/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --error-log-path=/var/log/nginx/error.log \
+        --http-log-path=/var/log/nginx/access.log \
+        --pid-path=/var/run/nginx.pid \
+        --lock-path=/var/run/nginx.lock \
+        --with-http_ssl_module \
+        --with-http_v2_module \
+        --with-http_v3_module \
+        --with-http_realip_module \
+        --with-http_stub_status_module \
+        --with-http_gzip_static_module \
+        --with-stream \
+        --with-stream_ssl_module
+    
+    # Build and install
+    log_info "Building NGINX (this may take several minutes)"
+    make -j"$(nproc 2>/dev/null || echo 2)"
+    sudo make install
+    
+    # Create systemd service
+    sudo tee /etc/systemd/system/nginx.service > /dev/null <<EOF
 [Unit]
 Description=The NGINX HTTP and reverse proxy server
-After=network.target
+After=network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking
-PIDFile=/usr/local/logs/nginx.pid
+PIDFile=/var/run/nginx.pid
 ExecStartPre=/usr/local/sbin/nginx -t
 ExecStart=/usr/local/sbin/nginx
 ExecReload=/usr/local/sbin/nginx -s reload
@@ -315,46 +464,29 @@ PrivateTmp=true
 WantedBy=multi-user.target
 EOF
     
-    systemctl daemon-reload
-    log_info "Installed nginx.service systemd unit"
-  fi
-  
-  # Verify the installation
-  if command -v nginx >/dev/null; then
-    NGINX_VER=$(nginx -v 2>&1)
-    log_info "Installed NGINX version: $NGINX_VER"
+    # Create symlink
+    sudo ln -sf /usr/local/sbin/nginx /usr/bin/nginx
     
-    # Verify version matches what we expect
-    if [ "$CHANNEL" = "stable" ] && ! echo "$NGINX_VER" | grep -q "1.28"; then
-      log_warn "Installed version does not match stable channel (expected 1.28.x)"
-    elif [ "$CHANNEL" = "mainline" ] && ! echo "$NGINX_VER" | grep -q "1.27"; then
-      log_warn "Installed version does not match mainline channel (expected 1.27.x)"
-    fi
-  else
-    log_warn "nginx command not in PATH. You can run it with: /usr/local/sbin/nginx"
-  fi
-  
-  log_success "NGINX $VER installed from source"
-  log_info "You can start it with: sudo systemctl start nginx"
+    # Reload systemd
+    sudo systemctl daemon-reload
+    
+    # Cleanup
+    cd / && rm -rf "$build_dir"
+    
+    log_success "NGINX $version compiled and installed from source"
 }
 
 #########################################################################
-# MAIN SCRIPT EXECUTION
+# MAIN INSTALLATION LOGIC
 #########################################################################
 
-# Parse command line options
-# First check for direct parameters (bash -s stable)
-if [ $# -eq 1 ] && [[ "$1" =~ ^(stable|mainline)$ ]]; then
-    CHANNEL="$1"
-    log_info "Setting channel to $CHANNEL (from direct parameter)"
-# Otherwise parse traditional options
-else
-    while getopts "s:" opt; do
+main() {
+    # Parse command line options
+    while getopts "c:" opt; do
         case $opt in
-            s) 
+            c) 
                 if [[ "$OPTARG" =~ ^(stable|mainline)$ ]]; then
                     CHANNEL="$OPTARG"
-                    log_info "Setting channel to $CHANNEL (from -s option)"
                 else
                     log_error "Channel must be 'stable' or 'mainline'"
                     usage
@@ -363,23 +495,86 @@ else
             *) usage ;;
         esac
     done
-fi
+    
+    # Also support direct parameter (for piping)
+    if [ $# -eq 1 ] && [[ "$1" =~ ^(stable|mainline)$ ]]; then
+        CHANNEL="$1"
+    fi
+    
+    # Check for root privileges
+    if [ "$EUID" -ne 0 ]; then
+        log_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+    
+    # Detect distribution
+    DISTRO=$(detect_distro)
+    log_info "Detected distribution: $DISTRO"
+    log_info "Selected channel: $CHANNEL"
+    
+    # Get distribution version
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        VERSION_ID="${VERSION_ID:-unknown}"
+    else
+        VERSION_ID="unknown"
+    fi
+    
+    # Check official support
+    if check_official_support "$DISTRO" "$VERSION_ID"; then
+        log_info "Distribution officially supported by nginx.org"
+    else
+        log_warn "Distribution not officially supported by nginx.org"
+        log_info "Will attempt installation anyway or fall back to source"
+    fi
+    
+    # Stop existing nginx if running
+    if systemctl is-active --quiet nginx 2>/dev/null; then
+        log_info "Stopping existing nginx service"
+        sudo systemctl stop nginx
+    fi
+    
+    # Install based on distribution
+    case "$DISTRO" in
+        rhel)
+            install_rhel_centos
+            ;;
+        fedora)
+            install_fedora
+            ;;
+        debian)
+            install_debian_ubuntu debian
+            ;;
+        ubuntu)
+            install_debian_ubuntu ubuntu
+            ;;
+        alpine)
+            install_alpine
+            ;;
+        amazon)
+            install_amazon
+            ;;
+        *)
+            log_warn "Unsupported distribution, falling back to source installation"
+            install_from_source
+            ;;
+    esac
+    
+    # Verify installation
+    if verify_nginx; then
+        log_success "NGINX installation completed successfully"
+        
+        # Enable and start service
+        sudo systemctl enable nginx
+        sudo systemctl start nginx
+        
+        log_info "NGINX service enabled and started"
+        log_info "You can check status with: sudo systemctl status nginx"
+    else
+        log_error "NGINX installation verification failed"
+        exit 1
+    fi
+}
 
-# Check for root privileges
-log_info "Checking for root privileges"
-(( EUID == 0 )) || { log_error "This script must be run as root"; exit 1; }
-
-# Detect distribution
-DISTRO=$(detect_distro)
-log_info "Detected distribution: $DISTRO"  # Try package installation first
-log_info "Attempting to install NGINX from official packages (channel: $CHANNEL)"
-if install_nginx_package; then
-  log_success "NGINX ($CHANNEL) installed via package manager"
-  exit 0
-fi
-
-# Fall back to source installation if package installation fails
-log_info "Package installation failed, falling back to source installation"
-install_nginx_from_source
-
-exit 0
+# Run main function
+main "$@"

--- a/nginx_installer.sh
+++ b/nginx_installer.sh
@@ -1,131 +1,230 @@
 #!/usr/bin/env bash
 #########################################################################
-# NGINX 1.28.0 Source Installer for Fedora
-# Compiles latest stable nginx with HTTP/3 support
+# NGINX 1.28.0 with Custom OpenSSL 3.5.0 Installer/Remover
+# Compiles nginx with latest OpenSSL for better HTTP/3 performance
 #########################################################################
 
 set -euo pipefail
 
 NGINX_VERSION="1.28.0"
-BUILD_DIR="/tmp/nginx-build-$$"
+OPENSSL_VERSION="3.5.0"
+BUILD_DIR="/tmp/nginx-openssl-build-$$"
 PREFIX="/usr/local/nginx"
 
 log_info() { echo -e "\033[0;34m[INFO]\033[0m $1"; }
 log_success() { echo -e "\033[0;32m[SUCCESS]\033[0m $1"; }
 log_error() { echo -e "\033[0;31m[ERROR]\033[0m $1"; }
+log_warn() { echo -e "\033[1;33m[WARN]\033[0m $1"; }
 
-# Check root
+# Spinner for long operations
+spinner() {
+    local pid=$1
+    local delay=0.1
+    local spinstr='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+    while [ "$(ps a | awk '{print $1}' | grep $pid)" ]; do
+        local temp=${spinstr#?}
+        printf " %c  " "$spinstr"
+        local spinstr=$temp${spinstr%"$temp"}
+        sleep $delay
+        printf "\b\b\b\b"
+    done
+    printf "    \b\b\b\b"
+}
+
+# Check for root privileges
 if [ "$EUID" -ne 0 ]; then
-    log_error "Run as root: sudo $0"
+    log_error "This script must be run as root: sudo $0"
     exit 1
 fi
 
-log_info "Installing Nginx $NGINX_VERSION from source with HTTP/3"
+# Function to remove existing nginx installation
+remove_nginx() {
+    log_info "Removing existing nginx installation..."
+    
+    # Stop nginx service
+    log_info "Stopping nginx service..."
+    systemctl stop nginx 2>/dev/null || true
+    systemctl disable nginx 2>/dev/null || true
 
-# Remove existing nginx
-log_info "Removing existing nginx..."
-systemctl stop nginx 2>/dev/null || true
-dnf remove -y nginx nginx-* 2>/dev/null || true
+    # Remove systemd service file
+    log_info "Removing systemd service..."
+    rm -f /etc/systemd/system/nginx.service
+    systemctl daemon-reload
 
-# Install build dependencies
-log_info "Installing build dependencies..."
-# Fedora 42 uses dnf5 which has different syntax
-if dnf --version 2>/dev/null | grep -q "dnf5"; then
-    # dnf5 syntax
-    dnf install -y @development-tools
-    dnf install -y pcre2-devel zlib-devel openssl-devel wget gcc make
-else
-    # Legacy dnf syntax
-    dnf groupinstall -y "Development Tools"
-    dnf install -y pcre2-devel zlib-devel openssl-devel wget
-fi
+    # Remove nginx binaries
+    log_info "Removing nginx binaries..."
+    rm -f /usr/sbin/nginx /usr/bin/nginx
 
-# Create build directory
-mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
+    # Ask about configuration directory
+    read -p "Remove nginx configuration directory /etc/nginx? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf /etc/nginx
+        log_info "Removed /etc/nginx"
+    else
+        log_warn "Keeping /etc/nginx (your configurations are safe)"
+    fi
 
-# Download nginx source
-log_info "Downloading nginx $NGINX_VERSION source..."
-wget "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
-wget "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc"
+    # Remove other nginx directories
+    log_info "Removing nginx directories..."
+    rm -rf /usr/local/nginx
+    rm -rf /var/cache/nginx
+    rm -rf /var/log/nginx
 
-# Verify signature (optional)
-log_info "Extracting source..."
-tar xf "nginx-${NGINX_VERSION}.tar.gz"
-cd "nginx-${NGINX_VERSION}"
+    # Remove nginx user
+    log_info "Removing nginx user..."
+    userdel nginx 2>/dev/null || true
+    groupdel nginx 2>/dev/null || true
 
-# Configure with modules including HTTP/3
-log_info "Configuring build with HTTP/3 and modern modules..."
-./configure \
-    --prefix="$PREFIX" \
-    --sbin-path=/usr/sbin/nginx \
-    --conf-path=/etc/nginx/nginx.conf \
-    --error-log-path=/var/log/nginx/error.log \
-    --http-log-path=/var/log/nginx/access.log \
-    --pid-path=/run/nginx.pid \
-    --lock-path=/run/nginx.lock \
-    --http-client-body-temp-path=/var/cache/nginx/client_temp \
-    --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-    --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-    --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-    --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-    --user=nginx \
-    --group=nginx \
-    --with-compat \
-    --with-file-aio \
-    --with-threads \
-    --with-http_addition_module \
-    --with-http_auth_request_module \
-    --with-http_dav_module \
-    --with-http_flv_module \
-    --with-http_gunzip_module \
-    --with-http_gzip_static_module \
-    --with-http_mp4_module \
-    --with-http_random_index_module \
-    --with-http_realip_module \
-    --with-http_secure_link_module \
-    --with-http_slice_module \
-    --with-http_ssl_module \
-    --with-http_stub_status_module \
-    --with-http_sub_module \
-    --with-http_v2_module \
-    --with-http_v3_module \
-    --with-mail \
-    --with-mail_ssl_module \
-    --with-stream \
-    --with-stream_realip_module \
-    --with-stream_ssl_module \
-    --with-stream_ssl_preread_module
+    # Kill any remaining nginx processes
+    pkill -f nginx 2>/dev/null || true
 
-# Build
-log_info "Building nginx (this may take several minutes)..."
-make -j"$(nproc)"
+    # Remove from package manager if installed that way
+    if command -v dnf >/dev/null 2>&1; then
+        dnf remove -y nginx nginx-* 2>/dev/null || true
+    elif command -v apt >/dev/null 2>&1; then
+        apt remove --purge -y nginx nginx-* 2>/dev/null || true
+    fi
 
-# Install
-log_info "Installing nginx..."
-make install
+    log_success "Nginx removal completed!"
+    exit 0
+}
 
-# Create nginx user
-log_info "Creating nginx user..."
-if ! id nginx >/dev/null 2>&1; then
-    useradd --system --home /var/cache/nginx --shell /sbin/nologin --comment "nginx user" nginx
-    log_info "Created nginx user"
-else
-    log_info "nginx user already exists"
-fi
+# Function to install nginx with custom OpenSSL
+install_nginx() {
+    log_info "Installing Nginx $NGINX_VERSION with OpenSSL $OPENSSL_VERSION"
 
-# Create required directories
-log_info "Creating required directories..."
-mkdir -p /var/cache/nginx/{client_temp,proxy_temp,fastcgi_temp,uwsgi_temp,scgi_temp}
-mkdir -p /var/log/nginx
-mkdir -p /etc/nginx/{conf.d,snippets}
+    # Install build dependencies
+    log_info "Installing build dependencies..."
+    if dnf --version 2>/dev/null | grep -q "dnf5"; then
+        dnf install -y @development-tools >/dev/null 2>&1
+        dnf install -y pcre2-devel zlib-devel perl wget gcc make >/dev/null 2>&1
+    else
+        dnf groupinstall -y "Development Tools" >/dev/null 2>&1 || true
+        dnf install -y pcre2-devel zlib-devel perl wget gcc make >/dev/null 2>&1
+    fi
 
-# Set permissions
-chown -R nginx:nginx /var/cache/nginx /var/log/nginx
-chmod 755 /var/cache/nginx /var/log/nginx
+    # Create build directory
+    mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
 
-# Create systemd service
-log_info "Creating systemd service..."
-cat > /etc/systemd/system/nginx.service << 'EOF'
+    # Download OpenSSL source
+    log_info "Downloading OpenSSL $OPENSSL_VERSION..."
+    wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"
+    tar xf "openssl-${OPENSSL_VERSION}.tar.gz"
+
+    # Download nginx source
+    log_info "Downloading nginx $NGINX_VERSION source..."
+    wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
+    tar xf "nginx-${NGINX_VERSION}.tar.gz"
+
+    # Build OpenSSL first (static linking for nginx)
+    log_info "Configuring OpenSSL $OPENSSL_VERSION..."
+    cd "openssl-${OPENSSL_VERSION}"
+
+    # Configure OpenSSL with optimizations
+    ./Configure linux-x86_64 \
+        --prefix="$BUILD_DIR/openssl-install" \
+        --openssldir="$BUILD_DIR/openssl-install/ssl" \
+        enable-tls1_3 \
+        enable-ec_nistp_64_gcc_128 \
+        no-shared \
+        no-tests \
+        -fPIC \
+        -O3 \
+        -march=native >/dev/null 2>&1
+
+    log_info "Building OpenSSL (this takes a while)..."
+    make -j"$(nproc)" >/dev/null 2>&1 &
+    spinner $!
+    
+    log_info "Installing OpenSSL libraries..."
+    make install_sw >/dev/null 2>&1
+
+    cd ..
+
+    # Configure nginx with custom OpenSSL
+    log_info "Configuring nginx with custom OpenSSL..."
+    cd "nginx-${NGINX_VERSION}"
+
+    # Set OpenSSL paths
+    OPENSSL_PATH="$BUILD_DIR/openssl-install"
+    export CFLAGS="-I${OPENSSL_PATH}/include -O3 -march=native"
+    export LDFLAGS="-L${OPENSSL_PATH}/lib64 -L${OPENSSL_PATH}/lib"
+
+    ./configure \
+        --prefix="$PREFIX" \
+        --sbin-path=/usr/sbin/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --error-log-path=/var/log/nginx/error.log \
+        --http-log-path=/var/log/nginx/access.log \
+        --pid-path=/run/nginx.pid \
+        --lock-path=/run/nginx.lock \
+        --http-client-body-temp-path=/var/cache/nginx/client_temp \
+        --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+        --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+        --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+        --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+        --user=nginx \
+        --group=nginx \
+        --with-openssl="$BUILD_DIR/openssl-${OPENSSL_VERSION}" \
+        --with-compat \
+        --with-file-aio \
+        --with-threads \
+        --with-http_addition_module \
+        --with-http_auth_request_module \
+        --with-http_dav_module \
+        --with-http_flv_module \
+        --with-http_gunzip_module \
+        --with-http_gzip_static_module \
+        --with-http_mp4_module \
+        --with-http_random_index_module \
+        --with-http_realip_module \
+        --with-http_secure_link_module \
+        --with-http_slice_module \
+        --with-http_ssl_module \
+        --with-http_stub_status_module \
+        --with-http_sub_module \
+        --with-http_v2_module \
+        --with-http_v3_module \
+        --with-mail \
+        --with-mail_ssl_module \
+        --with-stream \
+        --with-stream_realip_module \
+        --with-stream_ssl_module \
+        --with-stream_ssl_preread_module \
+        --with-cc-opt="-O3 -march=native -mtune=native -fstack-protector-strong" \
+        --with-ld-opt="-Wl,-z,relro -Wl,-z,now" >/dev/null 2>&1
+
+    # Build nginx
+    log_info "Building nginx with custom OpenSSL (this may take several minutes)..."
+    make -j"$(nproc)" >/dev/null 2>&1 &
+    spinner $!
+
+    # Install nginx
+    log_info "Installing nginx..."
+    make install >/dev/null 2>&1
+
+    # Create nginx user if needed
+    if ! id nginx >/dev/null 2>&1; then
+        useradd --system --home /var/cache/nginx --shell /sbin/nologin --comment "nginx user" nginx
+        log_info "Created nginx user"
+    else
+        log_info "nginx user already exists"
+    fi
+
+    # Create required directories
+    log_info "Creating required directories..."
+    mkdir -p /var/cache/nginx/{client_temp,proxy_temp,fastcgi_temp,uwsgi_temp,scgi_temp}
+    mkdir -p /var/log/nginx
+    mkdir -p /etc/nginx/{conf.d,snippets}
+
+    # Set permissions
+    chown -R nginx:nginx /var/cache/nginx /var/log/nginx
+    chmod 755 /var/cache/nginx /var/log/nginx
+
+    # Create systemd service
+    log_info "Creating systemd service..."
+    cat > /etc/systemd/system/nginx.service << 'EOF'
 [Unit]
 Description=The NGINX HTTP and reverse proxy server
 Documentation=http://nginx.org/en/docs/
@@ -147,100 +246,105 @@ PrivateTmp=true
 WantedBy=multi-user.target
 EOF
 
-# Create basic nginx.conf if it doesn't exist
-if [ ! -f /etc/nginx/nginx.conf ]; then
-    log_info "Creating basic nginx.conf..."
-    cat > /etc/nginx/nginx.conf << 'EOF'
-user nginx;
-worker_processes auto;
-error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
+    # Reload systemd and enable service
+    systemctl daemon-reload
+    systemctl enable nginx >/dev/null 2>&1
 
-events {
-    worker_connections 1024;
+    # Test configuration and start
+    log_info "Testing nginx configuration..."
+    if ! /usr/sbin/nginx -t >/dev/null 2>&1; then
+        log_error "Nginx configuration test failed!"
+        exit 1
+    fi
+
+    log_info "Starting nginx..."
+    systemctl start nginx
+
+    # Cleanup build directory
+    cd / && rm -rf "$BUILD_DIR"
+
+    # Verify installation
+    log_success "Nginx $NGINX_VERSION with OpenSSL $OPENSSL_VERSION installation completed!"
+
+    # Show versions
+    nginx_version=$(/usr/sbin/nginx -v 2>&1)
+    openssl_version=$(/usr/sbin/nginx -V 2>&1 | grep -o 'OpenSSL [0-9]\+\.[0-9]\+\.[0-9]\+')
+
+    log_info "Installed version: $nginx_version"
+    log_info "Built with: $openssl_version"
+
+    # Check HTTP/3 support
+    if /usr/sbin/nginx -V 2>&1 | grep -q "http_v3_module"; then
+        log_success "✓ HTTP/3 support available"
+    else
+        log_error "✗ HTTP/3 support not available"
+    fi
+
+    # Check QUIC support in OpenSSL
+    if /usr/sbin/nginx -V 2>&1 | grep -q "OpenSSL 3\.5"; then
+        log_success "✓ OpenSSL 3.5.x with enhanced QUIC support"
+    else
+        log_info "OpenSSL version detected: $openssl_version"
+    fi
+
+    log_info "Nginx is running and enabled for startup"
+    log_info "Configuration files are in /etc/nginx/"
+    log_info "You can check status with: sudo systemctl status nginx"
+
+    # Show performance info
+    log_info "Performance optimizations applied:"
+    echo "  • Native CPU optimizations (-march=native -mtune=native)"
+    echo "  • OpenSSL 3.5.0 with latest QUIC improvements"
+    echo "  • Statically linked OpenSSL for better performance"
+    echo "  • Stack protection and security hardening enabled"
 }
 
-http {
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log  /var/log/nginx/access.log  main;
-
-    sendfile            on;
-    tcp_nopush          on;
-    tcp_nodelay         on;
-    keepalive_timeout   65;
-    types_hash_max_size 2048;
-
-    include             /etc/nginx/mime.types;
-    default_type        application/octet-stream;
-
-    include /etc/nginx/conf.d/*.conf;
-
-    server {
-        listen       80 default_server;
-        listen       [::]:80 default_server;
-        server_name  _;
-        root         /usr/share/nginx/html;
-
-        location / {
-            root   /usr/share/nginx/html;
-            index  index.html index.htm;
-        }
-
-        error_page   500 502 503 504  /50x.html;
-        location = /50x.html {
-            root   /usr/share/nginx/html;
-        }
-    }
+# Main script logic
+main() {
+    # Check if nginx is already installed
+    if command -v nginx >/dev/null 2>&1; then
+        # Nginx is installed - get version info
+        nginx_version=$(nginx -v 2>&1 | grep -o 'nginx/[0-9.]*' | cut -d'/' -f2)
+        openssl_info=$(nginx -V 2>&1 | grep -o 'built with OpenSSL [^[:space:]]*' 2>/dev/null || echo "OpenSSL info unavailable")
+        
+        log_warn "Existing nginx installation detected:"
+        log_info "Current version: nginx/$nginx_version"
+        log_info "$openssl_info"
+        echo
+        echo "What would you like to do?"
+        echo "1) Remove existing nginx installation"
+        echo "2) Install new nginx (will remove existing first)"
+        echo "3) Cancel and exit"
+        echo
+        read -p "Please choose (1/2/3): " -n 1 -r
+        echo
+        
+        case $REPLY in
+            1)
+                remove_nginx
+                ;;
+            2)
+                log_info "Proceeding with installation (existing nginx will be removed first)..."
+                # Remove existing nginx first, then install
+                systemctl stop nginx 2>/dev/null || true
+                rm -f /usr/sbin/nginx /usr/bin/nginx
+                install_nginx
+                ;;
+            3)
+                log_info "Operation cancelled by user"
+                exit 0
+                ;;
+            *)
+                log_error "Invalid choice. Exiting."
+                exit 1
+                ;;
+        esac
+    else
+        # No nginx installed - proceed with installation
+        log_info "No existing nginx installation detected"
+        install_nginx
+    fi
 }
-EOF
-fi
 
-# Create default web root
-mkdir -p /usr/share/nginx/html
-cat > /usr/share/nginx/html/index.html << 'EOF'
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Welcome to nginx!</title>
-</head>
-<body>
-    <h1>Welcome to nginx!</h1>
-    <p>nginx 1.28.0 with HTTP/3 support</p>
-    <p>Compiled from source on Fedora</p>
-</body>
-</html>
-EOF
-
-# Reload systemd and enable service
-systemctl daemon-reload
-systemctl enable nginx
-
-# Test configuration
-log_info "Testing nginx configuration..."
-/usr/sbin/nginx -t
-
-# Start nginx
-log_info "Starting nginx..."
-systemctl start nginx
-
-# Cleanup build directory
-cd / && rm -rf "$BUILD_DIR"
-
-# Verify installation
-log_success "Nginx $NGINX_VERSION installation completed!"
-nginx_version=$(/usr/sbin/nginx -v 2>&1)
-log_info "Installed version: $nginx_version"
-
-# Check HTTP/3 support
-if /usr/sbin/nginx -V 2>&1 | grep -q "http_v3_module"; then
-    log_success "✓ HTTP/3 support available"
-else
-    log_error "✗ HTTP/3 support not available"
-fi
-
-log_info "Nginx is running and enabled for startup"
-log_info "Configuration files are in /etc/nginx/"
-log_info "You can check status with: sudo systemctl status nginx"
+# Run main function
+main "$@"


### PR DESCRIPTION
Complete rewrite of the nginx installer script to always compile from source
with custom OpenSSL 3.5.0 for enhanced HTTP/3 and QUIC support.

Changes:
- Always compiles nginx 1.28.0 from source (no more package manager installs)
- Bundles OpenSSL 3.5.0 with enhanced QUIC performance improvements
- Enables all nginx modules including HTTP/3, stream, mail, and auth modules
- Adds CPU-specific optimizations (-march=native) for better performance
- Implements cleaner output with progress spinners instead of verbose logs
- Adds proper systemd service integration
- Includes removal functionality for existing nginx installations

Performance improvements:
- Statically linked OpenSSL for reduced overhead
- Native CPU instruction set optimizations
- Full HTTP/3 and QUIC protocol support
- Security hardening with stack protection

This script was refined with AI assistance, which was instrumental in
optimizing the build process and improving error handling. Without AI
collaboration, achieving this level of polish would not have been possible.