### PR TITLE
fix(nginx): harden error handling in bash and PowerShell installers

### DIFF
--- a/nginx/nginx_installer.ps1
+++ b/nginx/nginx_installer.ps1
@@ -425,10 +425,14 @@ export LDFLAGS='-lzstd'
     }
 
     New-Item -ItemType Directory -Path "$Script:BUILD_DIR/nginx-acme/objs" -Force | Out-Null
+    $acmeSo = 'target/release/libnginx_acme.so'
+    if (-not (Test-Path $acmeSo)) {
+        Stop-Script "ACME module not built: $acmeSo missing (cargo build may have failed)"
+    }
     try {
-        Copy-Item 'target/release/libnginx_acme.so' -Destination "$Script:BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" -Force -ErrorAction Stop
+        Copy-Item $acmeSo -Destination "$Script:BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" -Force -ErrorAction Stop
     } catch {
-        Stop-Script 'Failed to stage ACME module: target/release/libnginx_acme.so not found'
+        Stop-Script "Failed to stage ACME module: $($_.Exception.Message)"
     }
 
     Pop-Location # nginx-acme
@@ -746,7 +750,7 @@ WantedBy=multi-user.target
 
     bash -c 'systemctl daemon-reload' | Out-Null
     bash -c 'systemctl enable nginx' 2>&1 | Out-Null
-    bash -c 'nginx -t && systemctl start nginx' | Out-Null
+    bash -c '/usr/sbin/nginx -t && systemctl start nginx' | Out-Null
     if ($LASTEXITCODE -ne 0) { Stop-Script 'Failed to start nginx' }
 
     $opensslVer = (bash -c 'openssl version 2>/dev/null').Trim()
@@ -754,7 +758,7 @@ WantedBy=multi-user.target
     Write-Log 'INFO' "Nginx $Script:NGINX_VERSION with $opensslVer (system) installed"
     Write-Log 'INFO' 'Access: https://localhost'
     Write-Log 'INFO' 'Manage nginx with: systemctl {start|stop|reload|restart|status} nginx'
-    bash -c 'nginx -V 2>&1 | head -n1'
+    bash -c '/usr/sbin/nginx -V 2>&1 | head -n1'
 
     $testResult = Test-NginxInstallation
     if (-not $testResult) {
@@ -777,7 +781,7 @@ function Test-NginxInstallation {
         Write-Log 'INFO' 'ACME module present'
     }
 
-    $nginxTest = bash -c 'nginx -t 2>&1'
+    $nginxTest = bash -c '/usr/sbin/nginx -t 2>&1'
     if ($LASTEXITCODE -ne 0) {
         Write-Log 'ERROR' "nginx -t failed: $nginxTest"
         $ok = $false
@@ -823,16 +827,25 @@ function Remove-Nginx {
 function Test-RunningWebServers {
     $portsInUse = [System.Collections.Generic.List[string]]::new()
 
+    $portTool = (bash -c '(command -v lsof >/dev/null 2>&1 && echo lsof) || (command -v ss >/dev/null 2>&1 && echo ss) || echo none').Trim()
+    if ($portTool -eq 'none') {
+        Write-Log 'WARN' 'Neither lsof nor ss available; skipping port conflict check'
+        return
+    }
+
     foreach ($port in @(80, 443)) {
         $detectPid = @'
-port=$1
-if command -v lsof >/dev/null 2>&1; then
+tool=$1; port=$2
+if [ "$tool" = "lsof" ]; then
     lsof -ti ":$port" 2>/dev/null | head -n1
 else
-    ss -tlnp 2>/dev/null | awk -v p="$port" '$0 ~ ":"p"[[:space:]]" {match($0,/pid=([0-9]+)/,a); if(a[1]) {print a[1]; exit}}'
+    ss -tlnp 2>/dev/null | awk -v p="$port" '
+        $0 ~ ":"p"[[:space:]]" {
+            if (match($0, /pid=[0-9]+/)) { print substr($0, RSTART+4, RLENGTH-4); exit }
+        }'
 fi
 '@
-        $procId = (bash -c $detectPid 'detect-port' $port 2>$null)?.Trim()
+        $procId = (bash -c $detectPid 'detect-port' $portTool $port 2>$null)?.Trim()
         if ($procId) {
             $proc = (bash -c "ps -p $procId -o comm= 2>/dev/null || echo unknown").Trim()
             $portsInUse.Add("$port ($proc)")

--- a/nginx/nginx_installer.ps1
+++ b/nginx/nginx_installer.ps1
@@ -233,7 +233,7 @@ function Update-SystemPackages {
         }
         'pacman' {
             & pacman -Syu --noconfirm 2>&1 | Out-Null
-            if ($LASTEXITCODE -ne 0) { Stop-Script 'pacman upgrade failed' }
+            if ($LASTEXITCODE -ne 0) { Write-Log 'WARN' 'pacman upgrade failed' }
         }
         default {
             Write-Log 'WARN' 'Unable to detect package manager'
@@ -425,7 +425,11 @@ export LDFLAGS='-lzstd'
     }
 
     New-Item -ItemType Directory -Path "$Script:BUILD_DIR/nginx-acme/objs" -Force | Out-Null
-    Copy-Item 'target/release/libnginx_acme.so' -Destination "$Script:BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" -Force -ErrorAction SilentlyContinue
+    try {
+        Copy-Item 'target/release/libnginx_acme.so' -Destination "$Script:BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" -Force -ErrorAction Stop
+    } catch {
+        Stop-Script 'Failed to stage ACME module: target/release/libnginx_acme.so not found'
+    }
 
     Pop-Location # nginx-acme
     Pop-Location # nginx
@@ -820,7 +824,15 @@ function Test-RunningWebServers {
     $portsInUse = [System.Collections.Generic.List[string]]::new()
 
     foreach ($port in @(80, 443)) {
-        $procId = (bash -c "lsof -ti :$port 2>/dev/null | head -n1" 2>$null)?.Trim()
+        $detectPid = @'
+port=$1
+if command -v lsof >/dev/null 2>&1; then
+    lsof -ti ":$port" 2>/dev/null | head -n1
+else
+    ss -tlnp 2>/dev/null | awk -v p="$port" '$0 ~ ":"p"[[:space:]]" {match($0,/pid=([0-9]+)/,a); if(a[1]) {print a[1]; exit}}'
+fi
+'@
+        $procId = (bash -c $detectPid 'detect-port' $port 2>$null)?.Trim()
         if ($procId) {
             $proc = (bash -c "ps -p $procId -o comm= 2>/dev/null || echo unknown").Trim()
             $portsInUse.Add("$port ($proc)")
@@ -862,5 +874,6 @@ try {
         }
     }
 } finally {
+    Stop-Transcript -ErrorAction SilentlyContinue
     Remove-Item $Script:BUILD_DIR -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/nginx/nginx_installer.sh
+++ b/nginx/nginx_installer.sh
@@ -349,7 +349,8 @@ Build-Nginx() {
     fi
     
     mkdir -p "$BUILD_DIR/nginx-acme/objs"
-    cp target/release/libnginx_acme.so "$BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" || true
+    cp target/release/libnginx_acme.so "$BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" \
+        || Stop-Script "Failed to stage ACME module: target/release/libnginx_acme.so not found"
     
     Write-Log INFO "ACME module built successfully"
     Write-Log INFO "Build complete"
@@ -553,7 +554,7 @@ Install-Nginx() {
     fi
     
     # Install binaries
-    cd "$BUILD_DIR/nginx"
+    cd "$BUILD_DIR/nginx" || Stop-Script "Cannot cd to $BUILD_DIR/nginx"
     local output
     if ! output=$(make install 2>&1); then
         Write-Log ERROR "Install output: $(echo "$output" | tail -10)"
@@ -646,7 +647,10 @@ EOF
     
     systemctl daemon-reload
     systemctl enable nginx >/dev/null 2>&1
-    nginx -t && systemctl start nginx
+    if ! nginx -t; then
+        Stop-Script "nginx configuration test failed — check the error above"
+    fi
+    systemctl start nginx || Stop-Script "Failed to start nginx service"
     
     local openssl_ver
     openssl_ver=$(openssl version 2>/dev/null | awk '{print $1" "$2}' || echo "OpenSSL unknown")
@@ -716,7 +720,13 @@ Test-RunningWebServers() {
 
     for port in 80 443; do
         local pid
-        pid=$(lsof -ti :"$port" 2>/dev/null | head -n1 || true)
+        if command -v lsof >/dev/null 2>&1; then
+            pid=$(lsof -ti :"$port" 2>/dev/null | head -n1 || true)
+        else
+            pid=$(ss -tlnp 2>/dev/null \
+                | awk -v p="${port}" '$0 ~ ":"p"[[:space:]]" {match($0,/pid=([0-9]+)/,a); if(a[1]) {print a[1]; exit}}' \
+                || true)
+        fi
         if [[ -n "$pid" ]]; then
             local proc
             proc=$(ps -p "$pid" -o comm= 2>/dev/null || echo "unknown")

--- a/nginx/nginx_installer.sh
+++ b/nginx/nginx_installer.sh
@@ -349,8 +349,10 @@ Build-Nginx() {
     fi
     
     mkdir -p "$BUILD_DIR/nginx-acme/objs"
-    cp target/release/libnginx_acme.so "$BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" \
-        || Stop-Script "Failed to stage ACME module: target/release/libnginx_acme.so not found"
+    local acme_so="target/release/libnginx_acme.so"
+    [[ -f "$acme_so" ]] || Stop-Script "ACME module not built: $acme_so missing (cargo build may have failed)"
+    cp "$acme_so" "$BUILD_DIR/nginx-acme/objs/ngx_http_acme_module.so" \
+        || Stop-Script "Failed to stage ACME module: cp failed (check disk space or permissions)"
     
     Write-Log INFO "ACME module built successfully"
     Write-Log INFO "Build complete"
@@ -647,7 +649,7 @@ EOF
     
     systemctl daemon-reload
     systemctl enable nginx >/dev/null 2>&1
-    if ! nginx -t; then
+    if ! /usr/sbin/nginx -t; then
         Stop-Script "nginx configuration test failed — check the error above"
     fi
     systemctl start nginx || Stop-Script "Failed to start nginx service"
@@ -657,7 +659,7 @@ EOF
     Write-Log INFO "Nginx ${NGINX_VERSION} with ${openssl_ver} (system) installed"
     Write-Log INFO "Access: https://localhost"
     Write-Log INFO "Manage nginx with: systemctl {start|stop|reload|restart|status} nginx"
-    nginx -V 2>&1 | head -n1 || true
+    /usr/sbin/nginx -V 2>&1 | head -n1 || true
     
     Test-NginxInstallation || Write-Log WARN "Post-install checks detected issues"
 }
@@ -676,7 +678,7 @@ Test-NginxInstallation() {
         Write-Log INFO "ACME module present"
     fi
     
-    if ! nginx -t >/dev/null 2>&1; then
+    if ! /usr/sbin/nginx -t >/dev/null 2>&1; then
         Write-Log ERROR "nginx -t failed"
         return 1
     fi
@@ -717,14 +719,25 @@ Remove-Nginx() {
 
 Test-RunningWebServers() {
     local ports_in_use=()
+    local has_lsof=0 has_ss=0
+    command -v lsof >/dev/null 2>&1 && has_lsof=1
+    command -v ss   >/dev/null 2>&1 && has_ss=1
+
+    if [[ $has_lsof -eq 0 && $has_ss -eq 0 ]]; then
+        Write-Log WARN "Neither lsof nor ss available; skipping port conflict check"
+        return 0
+    fi
 
     for port in 80 443; do
         local pid
-        if command -v lsof >/dev/null 2>&1; then
+        if [[ $has_lsof -eq 1 ]]; then
             pid=$(lsof -ti :"$port" 2>/dev/null | head -n1 || true)
         else
             pid=$(ss -tlnp 2>/dev/null \
-                | awk -v p="${port}" '$0 ~ ":"p"[[:space:]]" {match($0,/pid=([0-9]+)/,a); if(a[1]) {print a[1]; exit}}' \
+                | awk -v p="${port}" '
+                    $0 ~ ":"p"[[:space:]]" {
+                        if (match($0, /pid=[0-9]+/)) { print substr($0, RSTART+4, RLENGTH-4); exit }
+                    }' \
                 || true)
         fi
         if [[ -n "$pid" ]]; then


### PR DESCRIPTION
## Summary

Zeven bugs gevonden via vergelijking van `nginx_installer.sh` / `.ps1` (Stensel8/Scripts) met de Toolbox patch-1 branch, en door code-analyse.

### Fixes

**nginx_installer.sh**
- **ACME staging copy** (`Build-Nginx`): `|| true` vervangen door `|| Stop-Script "..."` — een mislukte copy wordt nu direct zichtbaar in plaats van stil door te gaan, waarna nginx niet start omdat het `.so`-bestand ontbreekt
- **`cd` in `Install-Nginx`**: ontbrekende foutafhandeling toegevoegd (`|| Stop-Script`) zodat een mislukking een leesbare foutmelding geeft in plaats van een stille `set -e` exit
- **`nginx -t && systemctl start`**: vervangen door `if ! nginx -t; then Stop-Script ...; fi` + aparte `systemctl start ... || Stop-Script` — geeft een expliciete logentry bij config-fouten
- **`lsof` in `Test-RunningWebServers`**: availability-check toegevoegd met `ss`-fallback — op minimale containers/images zonder `lsof` werd de port-check stil overgeslagen

**nginx_installer.ps1**
- **ACME staging copy** (`Build-Nginx`): `ErrorAction SilentlyContinue` → `ErrorAction Stop` in een `try/catch` met `Stop-Script`
- **pacman in `Update-SystemPackages`**: `Stop-Script` → `Write-Log 'WARN'` zodat het gedrag gelijk is aan de bash-variant (pacman upgrade-fouten zijn niet fataal)
- **`finally`-blok**: `Stop-Transcript` toegevoegd zodat de log altijd correct afgesloten wordt, ook bij een geforceerde onderbreking

## Test plan

- [x] Bash syntax check: `bash -n nginx/nginx_installer.sh`
- [x] Handmatig testen op een Debian/Ubuntu container (apt-pad)
- [x] Handmatig testen op een Fedora/RHEL container (dnf-pad)
- [ ] Verifieer dat een opzettelijk verkeerde cargo-output de ACME-fout nu zichtbaar maakt
- [x] Verifieer `Test-RunningWebServers` op een systeem zonder `lsof`

https://claude.ai/code/session_01QuVvMsLEmrc5iLdMM5R3up

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuVvMsLEmrc5iLdMM5R3up)_